### PR TITLE
Fix+tests: include overrides in template vars

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.github.shopsmart/clj-infrastructure "0.1.2"
+(defproject com.github.shopsmart/clj-infrastructure "0.1.3"
   :description "Infrastructure helpers for AWS, database, etc."
   :url "https://github.com/shopsmart/clj-foundation"
 

--- a/src/clj_infrastructure/db.clj
+++ b/src/clj_infrastructure/db.clj
@@ -175,6 +175,7 @@
 
   (->> kvs
        (partition 2)
+       (into (vec @dbconfig-overrides))
        (reduce
         (fn [result [k v]]
           (let [setting-namespace (db-setting? k)]

--- a/test/clj_infrastructure/db_test.clj
+++ b/test/clj_infrastructure/db_test.clj
@@ -106,13 +106,25 @@
 
   (testing "simple prepare with configuration set using dbconfig-override."
     (jdbc/with-db-connection [conn (dbconfig {} DB-SPEC)]
-      (dbconfig-override SQL-FN jdbc/query CONNECTION conn ABORT?-FN (constantly true))
+      (dbconfig-override SQL-FN jdbc/query
+                         CONNECTION conn
+                         ABORT?-FN (constantly true)
+                         :sound-column "sound"
+                         :default-animal "Pig")     ; Note: have to be careful what you override: the names are global!
 
-      (let [make-sound (prepare "select sound from test_data where name='Pig';")
-            result     (make-sound ::row-fn :sound)]
+      (testing "Prepare/execute"
+        (let [make-sound (prepare "select ${sound-column} from test_data where name='${default-animal}';")
+              result     (make-sound ::row-fn :sound)]
 
-        (is (= "Oink" (first result)))
-        (is (= 1 (count result))))))
+          (is (= "Oink" (first result)))
+          (is (= 1 (count result)))))
+
+      (testing "Prepare/execute, but overridding the dbconfig-override variable"
+        (let [make-sound (prepare "select ${sound-column} from test_data where name='${default-animal}';" :default-animal "Cow")
+              result     (make-sound ::row-fn :sound)]
+
+          (is (= "Moo" (first result)))
+          (is (= 1 (count result)))))))
 
 
   (testing "Prepare with both templates and bind variables; configuration set using parameters"


### PR DESCRIPTION
* We failed to merge dbconfig-override settings into the varmaps.  This fixes that.