### PR TITLE
Remove explicit schema for DB independence

### DIFF
--- a/test/clj_infrastructure/db_test.clj
+++ b/test/clj_infrastructure/db_test.clj
@@ -46,9 +46,9 @@
 
 (defn test-table [basename] (str basename (System/getProperty "user.name"))) ; so it's impossible for two users' tests to conflict
 
-(def settings {:redshift {:test-table   (test-table "integration_or_unit_test.transaction_test_777")
-                          :test-table-2 (test-table "integration_or_unit_test.transaction_test_999")
-                          :spec         (secrets :contentshift)}
+(def settings {:redshift {:test-table     (test-table "transaction_test_777")
+                          :test-table-2   (test-table "transaction_test_999")
+                          :spec           (secrets :contentshift)}
 
                :h2 {:test-table   "transaction_test_777"
                     :test-table-2 "transaction_test_999"


### PR DESCRIPTION
Rely on db user's search_path (postgres) or default schema to place the tables in the correct schema.  Remove explicit schema specification in DDL and SQL so that tests run out of the box.