### PR TITLE
Add function for processing query resultsets as a cursor (in batches)…

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.github.shopsmart/clj-infrastructure "0.1.19"
+(defproject com.github.shopsmart/clj-infrastructure "0.1.20"
   :description "Infrastructure helpers for AWS, database, etc."
   :url "https://github.com/shopsmart/clj-infrastructure"
 


### PR DESCRIPTION
… and modify the helper function to support that type of query if a result set fn is passed in